### PR TITLE
EXP-13297 - UI Tests: One drive: No sound is playing

### DIFF
--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionDownloadTask.h
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionDownloadTask.h
@@ -18,16 +18,4 @@
                          client:(ODataBaseClient *)client
              completionHandler:(MSDownloadCompletionHandler)completionHandler;
 
-/**
- Creates a Download task with the given request and client.
- @param request The mutableURL request. Must not be nil.
- @param client The client that will send the request. Must not be nil.
- @param skipAuthentication The parameter, indicating whether authentication should be skipped
- @param completionHandler The completion handler to call when the task has completed.
- */
-- (instancetype)initWithRequest:(NSMutableURLRequest *)request
-                         client:(ODataBaseClient *)client
-             skipAuthentication:(BOOL)skipAuthentication
-             completionHandler:(MSDownloadCompletionHandler)completionHandler;
-
 @end

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionDownloadTask.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionDownloadTask.m
@@ -18,20 +18,7 @@
                          client:(ODataBaseClient *)client
              completionHandler:(MSDownloadCompletionHandler)completionHandler
 {
-    return
-    [self
-     initWithRequest:request 
-     client:client
-     skipAuthentication:NO
-     completionHandler:completionHandler];
-}
-
-- (instancetype)initWithRequest:(NSMutableURLRequest *)request
-                         client:(ODataBaseClient *)client
-             skipAuthentication:(BOOL)skipAuthentication
-             completionHandler:(MSDownloadCompletionHandler)completionHandler
-{
-    self = [super initWithRequest:request client:client skipAuthentication:skipAuthentication];
+    self = [super initWithRequest:request client:client];
     if (self){
         _completionHandler = completionHandler;
     }
@@ -49,7 +36,10 @@
 {
     [self.client.logger logWithLevel:MSLogLevelLogVerbose message:@"Creating download task with request : %@", request];
     NSProgress *progress = [self createProgress];
-    return [self.client.httpProvider downloadTaskWithRequest:request progress:&progress completionHandler:^(NSURL *location, NSURLResponse *response, NSError *error){
+    
+    return [self.client.httpProvider downloadTaskWithRequest:request
+                                                    progress:&progress
+                                           completionHandler:^(NSURL *location, NSURLResponse *response, NSError *error) {
         self->_state = MSURLSessionTaskStateTaskCompleted;
         NSInteger statusCode = ((NSHTTPURLResponse *)response).statusCode;
         [self.client.logger logWithLevel:MSLogLevelLogVerbose message:@"Received download response with http status code %ld", statusCode];
@@ -57,12 +47,13 @@
             // The only response that should allow for the binary data to be in the file is a 200, otherwise it will be empty (304 no body)
             // or contain the error json blob which will be passed back in the error object if it exists
             // because this is a download task it will download the response to disk instead of memory
-            if ( statusCode != MSExpectedResponseCodesNotModified){
+            if ( statusCode != MSExpectedResponseCodesNotModified) {
                 error = [self readErrorFromFile:location response:response];
             }
             location = nil;
         }
-        if (self.completionHandler){
+        
+        if (self.completionHandler) {
             self.completionHandler(location, response, error);
         }
     }];

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionTask.h
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionTask.h
@@ -56,16 +56,6 @@ typedef MSRawDownloadCompletionHandler MSDownloadCompletionHandler;
                          client:(ODataBaseClient *)client;
 
 /**
- Creates an `MSURLSessionTask` with the given requests and client.
- @param request The request to use. Must not be nil.
- @param client The client to make the request. Must not be nil.
- @param skipAuthentication The parameter, indicating whether authentication should be skipped
- */
-- (instancetype)initWithRequest:(NSMutableURLRequest *)request
-                         client:(ODataBaseClient *)client
-             skipAuthentication:(BOOL)skipAuthentication;
-
-/**
  Executes the task.
  @warning The task may send an extra request to reauthenticate the session if the auth token has expired.
  */

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionTask.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionTask.m
@@ -7,7 +7,6 @@
 @interface MSURLSessionTask()
 
 @property (readonly) NSMutableURLRequest *request;
-@property (nonatomic, assign) BOOL skipAuthentication;
 
 @end
 
@@ -16,13 +15,6 @@
 - (instancetype)initWithRequest:(NSMutableURLRequest *)request
                          client:(ODataBaseClient *)client
 {
-    return [self initWithRequest:request client:client skipAuthentication:NO];
-}
-
-- (instancetype)initWithRequest:(NSMutableURLRequest *)request
-                         client:(ODataBaseClient *)client
-             skipAuthentication:(BOOL)skipAuthentication
-{
     NSParameterAssert(request);
     NSParameterAssert(client);
     
@@ -30,7 +22,6 @@
     if (self){
         _client = client;
         _request = request;
-        _skipAuthentication = skipAuthentication;
         _state = MSURLSessionTaskStateTaskCreated;
     }
     return self;
@@ -46,12 +37,7 @@
     {
         [self.request setValue:@"text/plain" forHTTPHeaderField:@"Content-Type"];
     }
-
-    if (self.skipAuthentication) {
-        [self startTaskWithRequest:self.request];
-        return;
-    }
-
+    
     [self.client.authenticationProvider appendAuthenticationHeaders:self.request completion:^(NSMutableURLRequest *request, NSError *error){
         if (self.state != MSURLSessionTaskStateTaskCanceled){
             if (!error){

--- a/MSGraphSDK/MSGraphCoreSDK/requests/MSGraphDriveItemContentRequest.h
+++ b/MSGraphSDK/MSGraphCoreSDK/requests/MSGraphDriveItemContentRequest.h
@@ -9,8 +9,6 @@ typedef void(^MSGraphDriveItemUploadCompletionHandler)(MSGraphDriveItem *respons
 
 @interface MSGraphDriveItemContentRequest : MSRequest
 
-- (NSMutableURLRequest *) download;
-
 - (MSURLSessionDownloadTask *) downloadWithCompletion:(MSDownloadCompletionHandler)completionHandler;
 
 - (MSURLSessionUploadTask *) uploadFromData:(NSData *)data

--- a/MSGraphSDK/MSGraphCoreSDK/requests/MSGraphDriveItemContentRequest.h
+++ b/MSGraphSDK/MSGraphCoreSDK/requests/MSGraphDriveItemContentRequest.h
@@ -9,7 +9,7 @@ typedef void(^MSGraphDriveItemUploadCompletionHandler)(MSGraphDriveItem *respons
 
 @interface MSGraphDriveItemContentRequest : MSRequest
 
-- (instancetype)initWithDownloadURL:(NSURL *)url client:(ODataBaseClient *)client;
+- (NSMutableURLRequest *) download;
 
 - (MSURLSessionDownloadTask *) downloadWithCompletion:(MSDownloadCompletionHandler)completionHandler;
 

--- a/MSGraphSDK/MSGraphCoreSDK/requests/MSGraphDriveItemContentRequest.m
+++ b/MSGraphSDK/MSGraphCoreSDK/requests/MSGraphDriveItemContentRequest.m
@@ -14,25 +14,7 @@
 
 @end
 
-@interface MSGraphDriveItemContentRequest ()
-
-@property (nonatomic, assign) BOOL skipAuthentication;
-
-@end
-
 @implementation MSGraphDriveItemContentRequest
-
-- (instancetype)initWithDownloadURL:(NSURL *)url client:(ODataBaseClient *)client {
-    self = [super initWithURL:url client:client];
-    if (self != nil) {
-        // EXP-11490
-        // no need to add authorization headers when using direct download url
-        // furthermore, it can cause "unauthorized error"
-        // so we skip authorization
-        _skipAuthentication = YES;
-    }
-    return self;
-}
 
 - (NSMutableURLRequest *) download
 {
@@ -45,7 +27,6 @@
 {
     MSURLSessionDownloadTask *task = [[MSURLSessionDownloadTask alloc] initWithRequest:[self download]
                                                                                 client:self.client
-                                                                    skipAuthentication:self.skipAuthentication
                                                                      completionHandler:completionHandler];
     [task execute];
     return task;


### PR DESCRIPTION
__Ticket link__

[EXP-13297](https://readdle-j.atlassian.net/browse/EXP-13297)
[EXP-13296](https://readdle-j.atlassian.net/browse/EXP-13296)

__PR description__

- Deleted the skip authentication because the logic in RSOneDriveOnlineClient and RSOffice365SharepointOnlineClient changed

__PR submission checklist__

- [x] PR name contains Jira ticket number
- [x] PR have correct target branch
- [x] .s7substat has correct subrepos revisions
- [x] Common ([Obj-C](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/3802038524/Common+Objective-C+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams) / [Swift](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4662394906/Common+Swift+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams)) and your team's coding conventions and style guidelines are followed
- [x] Unit tests to cover the critical parts of the code are written
- [x] Relevant documentation updated / added if needed
- [x] Self-reviewed using the [self-review checklist](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4645978135) prior to submitting a PR
- [x] All recommendations from the [How to create Pull Request](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4568416271/How+to+create+Pull+Request+PR) document are followed


[EXP-13297]: https://readdle-j.atlassian.net/browse/EXP-13297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXP-13296]: https://readdle-j.atlassian.net/browse/EXP-13296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ