### PR TITLE
EXP-13955: Let's not

### DIFF
--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionTask.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionTask.m
@@ -82,9 +82,6 @@
         }];
     }
     else {
-        NSString *const warning = @"Attempted to start MSURLSessionTask without a throttling coordinator.";
-        NSAssert(NO, warning);
-        [self.client.logger logWithLevel:MSLogLevelLogWarn message:warning];
         [self->_innerTask resume];
     }
 }


### PR DESCRIPTION
__Ticket link__

[EXP-13955](https://readdle-j.atlassian.net/browse/EXP-13955)

__PR description__

- An assertion failure occurs when trying to add a SharePoint connection
- Upon adding a SharePoint connection, at some point the authenticator creates an ad-hoc Graph SDK client which. At this point the server configuration is not complete, since we're doing the request for exactly that, to fill in the missing data in the server configuration. I believe this is valid and should be allowed. 
- I'm removing the assert 🤷‍♂️ 

__PR submission checklist__

- [x] PR name contains Jira ticket number
- [x] PR have correct target branch
- [ ] .s7substat has correct subrepos revisions
- [ ] Common ([Obj-C](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/3802038524/Common+Objective-C+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams) / [Swift](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4662394906/Common+Swift+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams)) and your team's coding conventions and style guidelines are followed
- [ ] Unit tests to cover the critical parts of the code are written
- [ ] Relevant documentation updated / added if needed
- [ ] Self-reviewed using the [self-review checklist](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4645978135) prior to submitting a PR
- [ ] All recommendations from the [How to create Pull Request](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4568416271/How+to+create+Pull+Request+PR) document are followed
