### PR TITLE
EXP-17884 Fix logger crash

### DIFF
--- a/MSGraphSDK/Common/MSLoggerProtocol.h
+++ b/MSGraphSDK/Common/MSLoggerProtocol.h
@@ -42,6 +42,7 @@ typedef NS_ENUM(NSInteger, MSLogLevel){
  @param messageFormat A string or format string and objects for the format string.
  @warning You should only log messages if the logLevel of the logger is set to that level or below.
  */
-- (void)logWithLevel:(MSLogLevel)level message:(NSString *)messageFormat, ...;
+- (void)logWithLevel:(MSLogLevel)level format:(NSString *)format, ... NS_FORMAT_FUNCTION(2, 3);
+- (void)logWithLevel:(MSLogLevel)level message:(NSString *)message;
 
 @end

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSCollectionRequest.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSCollectionRequest.m
@@ -24,7 +24,7 @@
                                    else{
                                        // There was a failure in parsing the item
                                        [self.client.logger logWithLevel:MSLogLevelLogError message:@"Failed to parse collection"];
-                                       [self.client.logger logWithLevel:MSLogLevelLogDebug message:@"Object failed  to parse : %@", obj];
+                                       [self.client.logger logWithLevel:MSLogLevelLogDebug format:@"Object failed  to parse : %@", obj];
                                        *stop = YES;
                                    }
                                }];
@@ -35,13 +35,13 @@
                                                                            additionalData:rawResponse];
                                }
                                else{
-                                   [self.client.logger logWithLevel:MSLogLevelLogDebug message:@"Failed to parse collection objects expected %ld there were %ld", [rawResponse[MSCollectionValueKey] count], [odObjects count]];
+                                   [self.client.logger logWithLevel:MSLogLevelLogDebug format:@"Failed to parse collection objects expected %lu there were %lu", (unsigned long)[rawResponse[MSCollectionValueKey] count], (unsigned long)[odObjects count]];
                                }
                                
                            }
                            else{
                                [self.client.logger logWithLevel:MSLogLevelLogError message:@"Collection contains no value property"];
-                               [self.client.logger logWithLevel:MSLogLevelLogDebug message:@"Response was : %@", rawResponse];
+                               [self.client.logger logWithLevel:MSLogLevelLogDebug format:@"Response was : %@", rawResponse];
                            }
                             return parsedCollection;
                        }

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSRequest.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSRequest.m
@@ -69,14 +69,14 @@
     NSParameterAssert(url);
     NSParameterAssert(client);
     
-    [client.logger logWithLevel:MSLogLevelLogDebug message:@" MSRequest init with URL : %@ options : %@", url, options];
+    [client.logger logWithLevel:MSLogLevelLogDebug format:@" MSRequest init with URL : %@ options : %@", url, options];
     self = [super init];
     if (self){
         // It may be best to make this an options object so it is type safe
         if (options){
             [options enumerateObjectsUsingBlock:^(id obj, NSUInteger index, BOOL *stop){
                 if (![obj isKindOfClass:[MSRequestOptions class]]){
-                    [client.logger logWithLevel:MSLogLevelLogError message:@" Option : %@ are not MSRequestOptions", obj];
+                    [client.logger logWithLevel:MSLogLevelLogError format:@" Option : %@ are not MSRequestOptions", obj];
                     NSAssert([obj isKindOfClass:[MSRequestOptions class]], @"Options must be of type MSRequestOptions");
                 }
             }];
@@ -97,13 +97,13 @@
 {
     NSParameterAssert(method);
     
-    [self.client.logger logWithLevel:MSLogLevelLogVerbose message:@" Creating Request with method : %@ body : %@ headers : %@", method, body, headers];
-    
+    [self.client.logger logWithLevel:MSLogLevelLogVerbose format:@" Creating Request with method : %@ body : %@ headers : %@", method, body, headers];
+
     MSRequestOptionsBuilder *optionsBuilder = [MSRequestOptionsBuilder optionsWithArray:self.options];
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@%@",[self.requestURL absoluteString], optionsBuilder.functionParams, optionsBuilder.queryOptions]];
    
-    [self.client.logger logWithLevel:MSLogLevelLogDebug message:@"Request url : %@", url];
-    
+    [self.client.logger logWithLevel:MSLogLevelLogDebug format:@"Request url : %@", url];
+
     // Apple tries to be smart but they are using the wrong eTag when making requests...
     // so we must disable the caching policy
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
@@ -134,8 +134,8 @@
 {
     NSParameterAssert(request);
     
-    [self.client.logger logWithLevel:MSLogLevelLogVerbose message:@"Creating Data task with request : %@", request];
-    
+    [self.client.logger logWithLevel:MSLogLevelLogVerbose format:@"Creating Data task with request : %@", request];
+
     return [self taskWithRequest:request completion:^(NSDictionary *rawResponse, NSError *error){
         if (!error){
             if (completionHandler && castBlock){
@@ -144,8 +144,8 @@
             }
         }
         else {
-            [self.client.logger logWithLevel:MSLogLevelLogError message:@"Error from data task : %@", error];
-            [self.client.logger logWithLevel:MSLogLevelLogError message:@"Caused by request %@", request];
+            [self.client.logger logWithLevel:MSLogLevelLogError format:@"Error from data task : %@", error];
+            [self.client.logger logWithLevel:MSLogLevelLogError format:@"Caused by request %@", request];
             if(completionHandler){
                 completionHandler(nil, error);
             }
@@ -190,7 +190,7 @@
                            odobjectWithDictionary:(MSObjectWithDictionary)castBlock
                                 completionHandler:(MSObjectCompletionHandler)completionHandler
 {
-    [self.client.logger logWithLevel:MSLogLevelLogVerbose message:@"Creating upload task with requests : %@", request];
+    [self.client.logger logWithLevel:MSLogLevelLogVerbose format:@"Creating upload task with requests : %@", request];
     return [[MSURLSessionUploadTask alloc] initWithRequest:request
                                                   fromFile:fileURL
                                                     client:self.client
@@ -207,7 +207,7 @@
                            odobjectWithDictionary:(MSObjectWithDictionary)castBlock
                                 completionHandler:(MSObjectCompletionHandler)completionHandler
 {
-     [self.client.logger logWithLevel:MSLogLevelLogVerbose message:@"Creating upload task with requests : %@", request];
+     [self.client.logger logWithLevel:MSLogLevelLogVerbose format:@"Creating upload task with requests : %@", request];
     return [[MSURLSessionUploadTask alloc] initWithRequest:request
                                                     data:data
                                                     client:self.client

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionDownloadTask.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionDownloadTask.m
@@ -51,7 +51,7 @@
 
 - (NSURLSessionDownloadTask *)taskWithRequest:(NSMutableURLRequest *)request
 {
-    [self.client.logger logWithLevel:MSLogLevelLogVerbose message:@"Creating download task with request : %@", request];
+    [self.client.logger logWithLevel:MSLogLevelLogVerbose format:@"Creating download task with request : %@", request];
     NSProgress *progress = [self createProgress];
     return [self.client.httpProvider downloadTaskWithRequest:request
                                                     progress:&progress
@@ -59,7 +59,7 @@
                                            completionHandler:^(NSURL *location, NSURLResponse *response, NSError *error) {
         self->_state = MSURLSessionTaskStateTaskCompleted;
         NSInteger statusCode = ((NSHTTPURLResponse *)response).statusCode;
-        [self.client.logger logWithLevel:MSLogLevelLogVerbose message:@"Received download response with http status code %ld", statusCode];
+        [self.client.logger logWithLevel:MSLogLevelLogVerbose format:@"Received download response with http status code %ld", statusCode];
         if (!error && statusCode != MSExpectedResponseCodesOK) {
             // The only response that should allow for the binary data to be in the file is a 200, otherwise it will be empty (304 no body)
             // or contain the error json blob which will be passed back in the error object if it exists
@@ -84,7 +84,7 @@
     NSData *responseData = [NSData dataWithContentsOfURL:fileLocation options:0 error:&error];
     if (error){
         [self.client.logger logWithLevel:MSLogLevelLogWarn message:@"Failed to read error from file"];
-        [self.client.logger logWithLevel:MSLogLevelLogDebug message:@"File read error : %@", responseData];
+        [self.client.logger logWithLevel:MSLogLevelLogDebug format:@"File read error : %@", responseData];
         // if we can't read the error form disk thats ok just created a malformed error down the line
         error = nil;
     }
@@ -92,7 +92,7 @@
     if (responseData){
         responseObject = [NSJSONSerialization JSONObjectWithData:responseData options:0 error:&error];
         if (error){
-            [self.client.logger logWithLevel:MSLogLevelLogWarn message:@"Error parsing error : %@", error];
+            [self.client.logger logWithLevel:MSLogLevelLogWarn format:@"Error parsing error : %@", error];
         }
     }
     // If we couldn't parse the error object from the file still return an error with the proper code and no MSError

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionTask.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionTask.m
@@ -59,7 +59,7 @@
             }
             else{
                 self->_state = MSURLSessionTaskStateTaskAuthFailed;
-                [self.client.logger logWithLevel:MSLogLevelLogError message:@"Authentication Failed with error :%@", error];
+                [self.client.logger logWithLevel:MSLogLevelLogError format:@"Authentication Failed with error :%@", error];
                 [self authenticationFailedWithError:error];
             }
         }
@@ -70,7 +70,7 @@
     self->_state = MSURLSessionTaskStateTaskExecuting;
     self->_innerTask = [self taskWithRequest:request];
     [self.client.logger logWithLevel:MSLogLevelLogInfo message:@"Created NSURLSessionTask"];
-    [self.client.logger logWithLevel:MSLogLevelLogVerbose message:@"Task Id : %ld", self->_innerTask.taskIdentifier];
+    [self.client.logger logWithLevel:MSLogLevelLogVerbose format:@"Task Id : %lu", (unsigned long)self->_innerTask.taskIdentifier];
 
     if (self.client.throttlingCoordinator) {
         NSURLSessionTask *__weak weakInnerTask = self->_innerTask;
@@ -90,7 +90,7 @@
 {
     [self.client.logger logWithLevel:MSLogLevelLogInfo message:@"Canceled task"];
     if (_innerTask){
-        [self.client.logger logWithLevel:MSLogLevelLogDebug message:@"inner task : %l", [_innerTask taskIdentifier]];
+        [self.client.logger logWithLevel:MSLogLevelLogDebug format:@"inner task : %lu", (unsigned long)[_innerTask taskIdentifier]];
         [_innerTask cancel];
     }
     _state = MSURLSessionTaskStateTaskCanceled;

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionUploadTask.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionUploadTask.m
@@ -72,9 +72,9 @@
         responseDictionary = [NSJSONSerialization dictionaryWithResponse:response responseData:data error:&error];
     }
     if (error){
-        [self.client.logger logWithLevel:MSLogLevelLogError message:@"Error from download response %@", error];
+        [self.client.logger logWithLevel:MSLogLevelLogError format:@"Error from download response %@", error];
         if (response){
-            [self.client.logger logWithLevel:MSLogLevelLogDebug message:@"Error from response : %@", response];
+            [self.client.logger logWithLevel:MSLogLevelLogDebug format:@"Error from response : %@", response];
         }
     }
 

--- a/MSGraphSDK/MSGraphSDK/MSLogger.m
+++ b/MSGraphSDK/MSGraphSDK/MSLogger.m
@@ -20,39 +20,51 @@
     _logLevel = logLevel;
 }
 
-- (void)logWithLevel:(MSLogLevel)level message:(NSString *)messageFormat, ...
+- (void)logWithLevel:(MSLogLevel)level format:(NSString *)format, ...
 {
-    if (level <= self.logLevel){
-        va_list args;
-        va_start(args, messageFormat);
-        NSString *logLevel = nil;
-        switch (level) {
-            case MSLogLevelLogError:
-                logLevel = @"ERROR :";
-                break;
-            case MSLogLevelLogWarn:
-                logLevel = @"WARNING :";
-                break;
-            case MSLogLevelLogInfo:
-                logLevel = @"INFO :";
-                break;
-            case MSLogLevelLogDebug:
-                logLevel = @"DEBUG : ";
-                break;
-            case MSLogLevelLogVerbose:
-                logLevel = @"VERBOSE :";
-                break;
-            default:
-                break;
-        }
-        NSString *message = nil;
-        if (messageFormat){
-            NSString *stringFormat = [NSString stringWithFormat:@"Graph SDK %@ %@", logLevel, messageFormat];
-           message = [[NSString alloc] initWithFormat:stringFormat arguments:args];
-        }
-        [self writeMessage:message];
-        va_end(args);
+    if (level > self.logLevel
+        || format == nil)
+    {
+        return;
     }
+
+    va_list args;
+    va_start(args, format);
+
+    [self logWithLevel:level message:[[NSString alloc] initWithFormat:format arguments:args]];
+
+    va_end(args);
+}
+
+- (void)logWithLevel:(MSLogLevel)level message:(NSString *)message
+{
+    if (level > self.logLevel) {
+        return;
+    }
+
+    NSString *logLevel = nil;
+
+    switch (level) {
+        case MSLogLevelLogError:
+            logLevel = @"ERROR :";
+            break;
+        case MSLogLevelLogWarn:
+            logLevel = @"WARNING :";
+            break;
+        case MSLogLevelLogInfo:
+            logLevel = @"INFO :";
+            break;
+        case MSLogLevelLogDebug:
+            logLevel = @"DEBUG : ";
+            break;
+        case MSLogLevelLogVerbose:
+            logLevel = @"VERBOSE :";
+            break;
+        default:
+            break;
+    }
+    
+    [self writeMessage:[NSString stringWithFormat:@"Graph SDK %@ %@", logLevel, message]];
 }
 
 - (void)writeMessage:(NSString *)message


### PR DESCRIPTION
__Ticket link__

[EXP-17884](https://readdle-j.atlassian.net/browse/EXP-17884)

__PR description__

Crash is happened when string contains extra `%s` placeholders . The logger starts to read the memory as c string looking for `\0` symbol and crashes accessing the wrong memory. This happens because method applies format logic to all strings, even when no parameters were passed and no need to perform formatting. In this case we were formatting the user response which can contain `%s`.
Fix by adding 2 versions of log method, one for string and one for format string with `NS_FORMAT_FUNCTION` macro which will add compile time checks and will trigger compile time error `Format string is not a string literal (potentially insecure)`

__PR submission checklist__

- [x] PR name contains Jira ticket number
- [x] PR have correct target branch
- [x] .s7substat has correct subrepos revisions
- [x] Common ([Obj-C](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/3802038524/Common+Objective-C+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams) / [Swift](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4662394906/Common+Swift+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams)) and your team's coding conventions and style guidelines are followed
- [x] All new UI components meet accessibility expectations according to the [Accessibility guide](https://readdle-c.atlassian.net/wiki/spaces/RD2/pages/5595496478/Accessibility+guide).
- [x] Unit tests to cover the critical parts of the code are written
- [x] Relevant documentation updated / added if needed [^1]
- [x] Self-reviewed using the [self-review checklist](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4645978135) prior to submitting a PR
- [x] All recommendations from the [How to create Pull Request](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4568416271/How+to+create+Pull+Request+PR) document are followed

[^1]: List of documents we maintain up to date:
    - [Accessibility Guide](https://readdle-c.atlassian.net/wiki/spaces/RD2/pages/5595496478/Accessibility+guide)


[EXP-17884]: https://readdle-j.atlassian.net/browse/EXP-17884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ