### PR TITLE
[deps rd2 merge/feature/DOC-14656-merge-with-master/prod/to/release/documents] merge feature DOC-14656-merge-with-master prod to release documents

### DIFF
--- a/MSGraphSDK/Common/PMSThrottlingCoordinator.h
+++ b/MSGraphSDK/Common/PMSThrottlingCoordinator.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+@protocol PMSThrottlingCoordinator <NSObject>
+
+/// Performs `requestBlock` as soon as the current per-tenant throttling state allows.
+/// - warning: The `requestBlock` is performed on an internal throttling queue. The block along with its captured resources is retained until the throttling
+/// ends.
+- (void)performThrottled:(void (NS_SWIFT_SENDABLE ^)(void))requestBlock;
+
+/// Parses `Retry-After` HTTP header from the `response` and updates per-tenant throttling state accordingly.
+/// - note: Only HTTP requests with status codes 429 and 503 are processed.
+- (void)updateThrottlingFromResponse:(NSURLResponse *)response;
+
+@end

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionDataTask.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionDataTask.m
@@ -62,6 +62,8 @@
                                               [self.class verboseDebugDescriptionForResponse:response withData:data]]];
         }
 
+        [self.client.throttlingCoordinator updateThrottlingFromResponse:response];
+
         if (self.completionHandler){
             self.completionHandler(resolvedResponse, resolvedError);
         }

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionDownloadTask.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionDownloadTask.m
@@ -69,6 +69,9 @@
             }
             location = nil;
         }
+
+        [self.client.throttlingCoordinator updateThrottlingFromResponse:response];
+
         if (self.completionHandler){
             self.completionHandler(location, response, error);
         }

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionTask.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionTask.m
@@ -71,7 +71,22 @@
     self->_innerTask = [self taskWithRequest:request];
     [self.client.logger logWithLevel:MSLogLevelLogInfo message:@"Created NSURLSessionTask"];
     [self.client.logger logWithLevel:MSLogLevelLogVerbose message:@"Task Id : %ld", self->_innerTask.taskIdentifier];
-    [self->_innerTask resume];
+
+    if (self.client.throttlingCoordinator) {
+        NSURLSessionTask *__weak weakInnerTask = self->_innerTask;
+        [self.client.throttlingCoordinator performThrottled:^{
+            // the task may have been cancelled by now, but `resume` should do nothing in that case.
+            // adding an `if (weakInnerTask.state == NSURLSessionTaskStateSuspended)` check here would
+            // only introduce a potential race condition.
+            [weakInnerTask resume];
+        }];
+    }
+    else {
+        NSString *const warning = @"Attempted to start MSURLSessionTask without a throttling coordinator.";
+        NSAssert(NO, warning);
+        [self.client.logger logWithLevel:MSLogLevelLogWarn message:warning];
+        [self->_innerTask resume];
+    }
 }
 
 - (void)cancel

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionTask.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionTask.m
@@ -82,9 +82,6 @@
         }];
     }
     else {
-        NSString *const warning = @"Attempted to start MSURLSessionTask without a throttling coordinator.";
-        NSAssert(NO, warning);
-        [self.client.logger logWithLevel:MSLogLevelLogWarn message:warning];
         [self->_innerTask resume];
     }
 }

--- a/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionUploadTask.m
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/MSURLSession/MSURLSessionUploadTask.m
@@ -77,6 +77,9 @@
             [self.client.logger logWithLevel:MSLogLevelLogDebug message:@"Error from response : %@", response];
         }
     }
+
+    [self.client.throttlingCoordinator updateThrottlingFromResponse:response];
+
     if (self.completionHandler){
         self.completionHandler(responseDictionary, error);
     }

--- a/MSGraphSDK/MSGraphCoreSDK/Core/ODataBaseClient.h
+++ b/MSGraphSDK/MSGraphCoreSDK/Core/ODataBaseClient.h
@@ -3,6 +3,7 @@
 #import "MSHttpProvider.h"
 #import "MSAuthenticationProvider.h"
 #import "MSLoggerProtocol.h"
+#import "PMSThrottlingCoordinator.h"
 
 @interface ODataBaseClient : NSObject
 
@@ -10,6 +11,8 @@
 @property NSURL *baseURL;
 
 @property (strong) id<MSHttpProvider> httpProvider;
+
+@property (strong) id<PMSThrottlingCoordinator> throttlingCoordinator;
 
 @property (strong) id<PMSLogger> logger;
 

--- a/MSGraphSDK/MSGraphSDK.xcodeproj/project.pbxproj
+++ b/MSGraphSDK/MSGraphSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01954A202DCCBD9B00D42FC9 /* PMSThrottlingCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 01515CF62DCCB4F5000BAC53 /* PMSThrottlingCoordinator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0E0CFD9D1D081FCD009F9F84 /* MSGraphProfilePhotoStreamRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0CFD9C1D081FCD009F9F84 /* MSGraphProfilePhotoStreamRequestTests.m */; };
 		0E0CFD9F1D0820A3009F9F84 /* MSGraphUserReferenceRequestBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0CFD9E1D0820A3009F9F84 /* MSGraphUserReferenceRequestBuilderTests.m */; };
 		0E0CFDA11D0820C5009F9F84 /* MSGraphUserReferenceRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0CFDA01D0820C5009F9F84 /* MSGraphUserReferenceRequestTest.m */; };
@@ -901,6 +902,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		01515CF62DCCB4F5000BAC53 /* PMSThrottlingCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PMSThrottlingCoordinator.h; sourceTree = "<group>"; };
 		0E0CFD9C1D081FCD009F9F84 /* MSGraphProfilePhotoStreamRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSGraphProfilePhotoStreamRequestTests.m; sourceTree = "<group>"; };
 		0E0CFD9E1D0820A3009F9F84 /* MSGraphUserReferenceRequestBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSGraphUserReferenceRequestBuilderTests.m; sourceTree = "<group>"; };
 		0E0CFDA01D0820C5009F9F84 /* MSGraphUserReferenceRequestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSGraphUserReferenceRequestTest.m; sourceTree = "<group>"; };
@@ -2051,6 +2053,7 @@
 				7C70E83D1C8776E5008A0C07 /* MSLoggerProtocol.h */,
 				7C12E5B41CA3469400328A79 /* MSGraphSDKVersion.h */,
 				7C12E5B51CA3469400328A79 /* MSGraphSDKVersion.m */,
+				01515CF62DCCB4F5000BAC53 /* PMSThrottlingCoordinator.h */,
 			);
 			path = Common;
 			sourceTree = SOURCE_ROOT;
@@ -2958,6 +2961,7 @@
 				7C6F5B751CB33B8B00EDF1C9 /* MSGraphGroupThreadsCollectionRequestBuilder.h in Headers */,
 				7C6F579B1CB33B8100EDF1C9 /* MSGraphFreeBusyStatus.h in Headers */,
 				7C6F5AAD1CB33B8B00EDF1C9 /* MSGraphDriveItemChildrenCollectionRequest.h in Headers */,
+				01954A202DCCBD9B00D42FC9 /* PMSThrottlingCoordinator.h in Headers */,
 				7C6F5AE51CB33B8B00EDF1C9 /* MSGraphEntityRequestBuilder.h in Headers */,
 				7C6F57971CB33B8100EDF1C9 /* MSGraphFileSystemInfo.h in Headers */,
 				7C6F5B171CB33B8B00EDF1C9 /* MSGraphGraphServiceDirectoryRolesCollectionRequest.h in Headers */,

--- a/MSGraphSDK/MSGraphSDK.xcodeproj/project.pbxproj
+++ b/MSGraphSDK/MSGraphSDK.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -3424,7 +3424,8 @@
 		10B4D1171AF8215D0083D86C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1400;
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1640;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					0EFE52531CEC9627002494E7 = {
@@ -3968,7 +3969,11 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/../OCMock/Source";
 				INFOPLIST_FILE = MSGraphSDKTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.-microsoft.opentech.MSGraphSDKTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -3984,7 +3989,11 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/../OCMock/Source";
 				INFOPLIST_FILE = MSGraphSDKTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.-microsoft.opentech.MSGraphSDKTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -4025,6 +4034,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -4087,6 +4097,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
@@ -4110,16 +4121,23 @@
 		10B4D1371AF8215D0083D86C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = MSGraphSDK/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACH_O_TYPE = staticlib;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Microsoft.MSGraph.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = MSGraphSDK;
 				SKIP_INSTALL = YES;
@@ -4129,16 +4147,23 @@
 		10B4D1381AF8215D0083D86C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = MSGraphSDK/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACH_O_TYPE = staticlib;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Microsoft.MSGraph.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = MSGraphSDK;
 				SKIP_INSTALL = YES;

--- a/MSGraphSDK/MSGraphSDK.xcodeproj/project.pbxproj
+++ b/MSGraphSDK/MSGraphSDK.xcodeproj/project.pbxproj
@@ -4136,7 +4136,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACH_O_TYPE = staticlib;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Microsoft.MSGraph.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = MSGraphSDK;
@@ -4162,7 +4161,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACH_O_TYPE = staticlib;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Microsoft.MSGraph.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = MSGraphSDK;


### PR DESCRIPTION
auto approve: merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the timing/queuing of all network task execution when a throttling coordinator is set, which can introduce hangs or ordering/race issues if the coordinator implementation is incorrect; otherwise behavior is unchanged when unset.
> 
> **Overview**
> Adds an injectable `PMSThrottlingCoordinator` (new public protocol and `ODataBaseClient.throttlingCoordinator`) to coordinate per-tenant throttling based on `Retry-After`.
> 
> All `MSURLSession*Task` variants now (a) gate `resume` via `performThrottled:` when configured and (b) report responses back via `updateThrottlingFromResponse:` so 429/503 responses can adjust future scheduling. The Xcode project is updated to expose the new header and includes minor build setting modernization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf7d00447a6e9253a97dd3b5277688e82f7d443c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->